### PR TITLE
Default constructor crash

### DIFF
--- a/boa_solidity/soldeployer.py
+++ b/boa_solidity/soldeployer.py
@@ -6,11 +6,11 @@ class SolDeployer:
     def __init__(self, abi, bytecode, filename=None, env=None):
         self.env = env or Env.get_singleton()
         self.abi = abi
-        self.types = [
+        self.types = next(iter([
             [x["type"] for x in entry["inputs"]]
             for entry in abi
             if entry["type"] == "constructor"
-        ][0]
+        ]), [])
         self.bytecode = bytecode
         self.filename = filename
         self.factory = ABIContractFactory.from_abi_dict(abi)


### PR DESCRIPTION
## Description
If constructor is not defined there will be no entry, hence empty list and `list index out of range` error. Made empty list by default.

## How to test
You can try compile this [contract](https://github.com/mds1/multicall/blob/main/src/Multicall3.sol).