### PR TITLE
compiler_args unused

### DIFF
--- a/boa_solidity/__init__.py
+++ b/boa_solidity/__init__.py
@@ -3,10 +3,10 @@ import solcx
 from .soldeployer import SolDeployer
 from pathlib import Path
 
-def load_partial_solc(filename: str, compiler_args = None, contract_name = None) -> SolDeployer:
+def load_partial_solc(filename: str, compiler_args = {}, contract_name = None) -> SolDeployer:
     if contract_name is None:
         contract_name = Path(filename).stem
-    compiled_src = solcx.compile_files([filename], output_values=["abi", "bin"])
+    compiled_src = solcx.compile_files([filename], output_values=["abi", "bin"], **compiler_args)
     abi = compiled_src[f"{filename}:{contract_name}"]["abi"]
     bytecode = compiled_src[f"{filename}:{contract_name}"]["bin"]
     bytecode = bytes.fromhex(bytecode)


### PR DESCRIPTION
## About
Forwarded `compiler_args` to `solcx.compile_files()`.

## Usage
Can be used as `load_partial_solc(..., compiler_args={"solc_version": "0.8.12"})`.